### PR TITLE
add C++ windows support

### DIFF
--- a/zed_cpp_sample/CMakeLists.txt
+++ b/zed_cpp_sample/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(${OPENCV_INCLUDE_DIRS})
 link_directories(${ZED_LIBRARY_DIR})
 link_directories(${CUDA_LIBRARY_DIRS})
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libdarknet/)
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libdarknet/build/darknet/x64)
 link_directories(${OpenCV_LIBRARY_DIRS})
 
 FILE(GLOB_RECURSE SRC_FILES src/*.cpp)
@@ -33,10 +34,16 @@ FILE(GLOB_RECURSE SRC_FILES src/*.cpp)
 ADD_EXECUTABLE(${execName} ${SRC_FILES})
 add_definitions(-std=c++11 -g -O3)
 
+IF (WIN32)
+	SET(darknet_libs yolo_cpp_dll)
+ELSEIF (UNIX)
+	SET(darknet_libs darknet)
+ENDIF ()
+
 # Add the required libraries for linking:
 TARGET_LINK_LIBRARIES(${execName}
                         ${ZED_LIBRARIES}
                         ${SPECIAL_OS_LIBS}
                         ${OpenCV_LIBRARIES}
-                        darknet
+                        ${darknet_libs}
                         ${CUDA_CUDA_LIBRARY} ${CUDA_CUDART_LIBRARY} ${CUDA_NPP_LIBRARIES_ZED})


### PR DESCRIPTION
#3 
I have tried successfully on Windows 10 VS2017 with openCV 3.4.0, CUDA 10.
I'm a new developer, I hope it works for more developers.
All VS sulotions have to be built under **Release** and **x64**
The followings are basic steps, which could be added into README in a suitable way.(Step3 is useless if my commit is merged)

## Before
Make sure the openCV version is lower than **3.4.0**, for the higher version has problem on compatibility with C language.
Make sure that you can follow the other zed examples and successfully run them

## Step1
Open libdarknet/build/darknet/yolo_cpp_dll.vcxproj in an editor and replace **CUDA x.x.targets** into your CUDA version (eg.CUDA 10.0.targets)

## Step2
Open yolo_cpp_dll.sln (or yolo_cpp_dll_no_gpu.sln if you don't use gpu). Make sure your openCV path is included in the right way
Build

## Step3
Open zed_cpp_sample\CmakeLists.txt 
[add]`link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libdarknet/build/darknet/x64)`
[change] from
`TARGET_LINK_LIBRARIES (darknet)`
to
`TARGET_LINK_LIBRARIES (yolo_cpp_dll)` or `(yolo_cpp_dll_no_gpu)`
Cmake and Compile the solution

## Step4
Copy dlls in /libdarknet//build/darknet/x64 into the sln folder
Run(follow the commond list in the README.md)