### PR TITLE
Use new class DETECTION(Structure) to match present Darknet

### DIFF
--- a/zed_python_sample/darknet_zed.py
+++ b/zed_python_sample/darknet_zed.py
@@ -60,7 +60,13 @@ class DETECTION(Structure):
                 ("prob", POINTER(c_float)),
                 ("mask", POINTER(c_float)),
                 ("objectness", c_float),
-                ("sort_class", c_int)]
+                ("sort_class", c_int),
+                ("uc", POINTER(c_float)),
+                ("points", c_int),
+                ("embeddings", POINTER(c_float)),
+                ("embedding_size", c_int),
+                ("sim", c_float),
+                ("track_id", c_int)]
 
 
 class IMAGE(Structure):


### PR DESCRIPTION
Avoid NULL pointer error with darknet_zed.py caused by outdated class Detection. Mentioned in #33 and #36. 